### PR TITLE
Api packager fix google package names

### DIFF
--- a/bin/grpc-api-packager
+++ b/bin/grpc-api-packager
@@ -7,9 +7,24 @@
  *
  * Example usage:
  *
- * Create the pubsub v1 API.
+ * Create the pubsub v1 API for all the default languages directly from the
+ * googleapis github project.
+ *
  * ```sh
  * $ grpc-api-packager --api_name=pubsub/v1
+ * ```
+ *
+ * Create the pubsub v1 API for ruby and python from a local copy of the
+ * googleapis github project.
+ *
+ * ```sh
+ * $ # clone the googleapis locally
+ * $ pushd ..
+ * $ git clone git@github.com:google/googleapis.git
+ * $ # do some work in it, e.g, to test a change
+ * $ ...
+ * $ popd  # back to the original wd
+ * $ grpc-api-packager --api_name=pubsub/v1  -r ../googleapis -l python ruby
  * ```
  *
  * Print full usage
@@ -96,6 +111,15 @@ var parseArgs = function parseArgs() {
     }
   );
   cli.addArgument(
+    [ '--package_prefix' ],
+    {
+      defaultValue: "",
+      help: 'Specifies a prefix to use when constructing package names\n' +
+        'if is_google_api is set, this defaults to "grpc-google-" otherwise ' +
+        ' the default is ""'
+    }
+  );
+  cli.addArgument(
     [ '-g', '--is_google_api' ],
     {
       defaultValue: true,
@@ -116,9 +140,13 @@ var main = function main() {
     isGoogleApi: cmdOpts.is_google_api,
     languages: cmdOpts.languages,
     outDir: cmdOpts.out_path,
+    pkgPrefix: cmdOpts.package_prefix,
     repoDir: cmdOpts.services_root,
     zipUrl: cmdOpts.zip_url
   };
+  if (opts.isGoogleApi && !opts.pkgPrefix) {
+    opts.pkgPrefix = 'grpc-google-';
+  }
   if (opts.outDir) {
     opts.outDir = path.resolve(opts.outDir);
   }

--- a/bin/grpc-api-packager
+++ b/bin/grpc-api-packager
@@ -111,13 +111,13 @@ var parseArgs = function parseArgs() {
  * main is the command line entry point when this file is run as a script.
  */
 var main = function main() {
-  var cmd_opts = parseArgs();
+  var cmdOpts = parseArgs();
   var opts = {
-    isGoogleApi: cmd_opts.is_google_api,
-    languages: cmd_opts.languages,
-    outDir: cmd_opts.out_path,
-    repoDir: cmd_opts.services_root,
-    zipUrl: cmd_opts.zip_url
+    isGoogleApi: cmdOpts.is_google_api,
+    languages: cmdOpts.languages,
+    outDir: cmdOpts.out_path,
+    repoDir: cmdOpts.services_root,
+    zipUrl: cmdOpts.zip_url
   };
   if (opts.outDir) {
     opts.outDir = path.resolve(opts.outDir);
@@ -126,11 +126,11 @@ var main = function main() {
     opts.repoDir = path.resolve(opts.repoDir);
   }
   var repo = new ApiRepo(opts);
-  var parts = cmd_opts.api_name.split('/');
-  var api_name = parts[0];
-  var api_version = parts[1];
+  var parts = cmdOpts.api_name.split('/');
+  var apiName = parts[0];
+  var apiVersion = parts[1];
   repo.on('ready', function() {
-    repo.buildPackages(api_name, api_version);
+    repo.buildPackages(apiName, apiVersion);
   });
   repo.on('err', function(err) {
     console.error('Could not build packages:', err);

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -37,6 +37,7 @@ function ApiRepo(opts) {
   this.languages = opts.languages || DEFAULT_LANGUAGES;
   this.outDir = opts.outDir || tmp.dirSync().name;
   this.repoDir = opts.repoDir;
+  this.pkgPrefix = opts.pkgPrefix;
   this.zipUrl = opts.zipUrl;
   this.isGoogleApi = !!opts.isGoogleApi;
   if (!(this.repoDir || this.zipUrl)) {
@@ -120,7 +121,7 @@ ApiRepo.prototype.buildPackages =
             'packageInfo': config.defaults,
             'generated': generated
           };
-          opts.packageInfo.api.name = name;
+          opts.packageInfo.api.name = that.pkgPrefix + name;
           opts.packageInfo.api.version = version;
           packager[l](opts, next);
         };


### PR DESCRIPTION
Ensures google packages are created with the 'grpc-google-' prefix (cf google/googleapis#4)

N.B This is based on #5 so that needs to be approved and merged before this.