### PR TITLE
Generate python namespace pkg list

### DIFF
--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -6,4 +6,4 @@ email: googleapis-packages@google.com
 github_user_uri: https://github.com/google
 homepage: https://github.com/google/googleapis
 license: Apache
-semantic_version: '1.0.999'
+semantic_version: '1.0.3'

--- a/config/api_defaults.yml
+++ b/config/api_defaults.yml
@@ -6,4 +6,4 @@ email: googleapis-packages@google.com
 github_user_uri: https://github.com/google
 homepage: https://github.com/google/googleapis
 license: Apache
-semantic_version: '1.0.3'
+semantic_version: '1.0.999'

--- a/config/python_pkg.yml
+++ b/config/python_pkg.yml
@@ -1,0 +1,4 @@
+# This contains python package names that should always be namespace packages
+namespaces:
+  - google
+  - google.logging

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,13 +15,15 @@ var loadYamlSync = function loadYamlSync(path) {
 var fallback = {
   apiDefaultsFile: configPath('api_defaults.yml'),
   depsFile: configPath('dependencies.yml'),
-  commonPbFile: configPath('common_protos.yml')
+  commonPbFile: configPath('common_protos.yml'),
+  pythonPkgFile: configPath('python_pkg.yml')
 };
 
 /**
  * Obtains an object containing the configured or default api/dependencies.
  */
 exports.packageInfo = function packageInfo(opts) {
+  opts = opts || {};
   var apiDefaultsFile = opts.apiDefaultsFile || fallback.apiDefaultsFile;
   var depsFile = opts.depsFile || fallback.depsFile;
   return {
@@ -31,9 +33,21 @@ exports.packageInfo = function packageInfo(opts) {
 };
 
 /**
- * Obtains an object containing the configured or default config values.
+ * Obtains an object containing information about the known common protobuf
+ * definitions.
  */
 exports.commonPbPkgs = function commonPbPkgs(opts) {
+  opts = opts || {};
   var commonPbFile = opts.commonPbFile || fallback.commonPbFile;
   return loadYamlSync(commonPbFile);
+};
+
+
+/**
+ * Obtains an object configuring information about the known python packages
+ */
+exports.pythonPkg = function pythonPkg(opts) {
+  opts = opts || {};
+  var pythonPkgFile = opts.pythonPkgFile || fallback.pythonPkgFile;
+  return loadYamlSync(pythonPkgFile);
 };

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -119,8 +119,9 @@ function makePythonPackage(opts, done) {
    * adds the necessary  __init__.py fiels.
    */
   var addPackageFiles = function addPackageFiles(next) {
-    console.log('in addPackageFiles:start %s', opts.top);
+    console.log('setting up python package in: %s', opts.top);
     var finished = false;
+    var nsPackages = [];
     var finder = new FindFiles({
       rootFolder : opts.top,
       filterFunction : function (_unused, stat) {
@@ -131,23 +132,29 @@ function makePythonPackage(opts, done) {
       if (!finished) {
         next(null);
         finished = true;
+        opts.packageInfo.api.nsPackages = nsPackages;
       }
     });
     finder.on("match", function(pkgDir) {
-      var src = path.join(opts.templateDir, 'namespace__init__.py')
-      if ((opts.buildCommonProtos && path.basename(pkgDir) !== 'google')
-          || (path.basename(pkgDir) === opts.packageInfo.api.version)) {
-        // the version folder is not a namespace package, nor are google
-        // sub-folders during the common proto builds
-        src = path.join(opts.templateDir, '__init__.py')
+      var commonNsPkgs = ['google', 'google.logging'];
+      var src = path.join(opts.templateDir, '__init__.py')
+      var basename = path.basename(pkgDir);
+      var pkgName = pkgDir.replace(opts.top, '').replace(/^\//, '');
+      var pkgName = pkgName.replace(/\//g, '.');
+      if (opts.buildCommonProtos && _.contains(commonNsPkgs, pkgName)) {
+        src = path.join(opts.templateDir, 'namespace__init__.py')
+        nsPackages.push(pkgName);
+      }
+      if (!opts.buildCommonProtos && basename !== opts.packageInfo.api.version) {
+        src = path.join(opts.templateDir, 'namespace__init__.py');
+        nsPackages.push(pkgName);
       }
       var dst = path.join(pkgDir, '__init__.py');
-      console.log('copying %s => %s', src, dst);
       fs.copySync(src, dst);
     });
     finder.on("error", function(err) {
       if (!finished) {
-        console.error('addPackageFiles:err', err);
+        console.error('failure in addPackageFiles %s', err);
         next(err);
         finished = true;
       }
@@ -173,7 +180,7 @@ function makePythonPackage(opts, done) {
     tasks.push(expand.bind(null, tmpl, dst, opts.packageInfo));
   });
 
-  async.parallel(tasks, function(err) {
+  async.series(tasks, function(err) {
     if (!err && opts.copyables.indexOf('PUBLISHING.rst') != -1) {
       console.log('The python package', packageName, 'was created in',
                   opts.top);
@@ -329,6 +336,7 @@ function expand(template, dst, params, done) {
   // renders and saves the output file
   var render = function render(err, renderable) {
     if (err) {
+      console.error('Expansion of %s to %s failed with %s', template, dst, err);
       done(err);
     } else {
       fs.writeFile(dst, Mustache.render(renderable, params), done);

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var async = require('async');
+var config = require('./config');
 var fs = require('fs-extra');
 var path = require('path');
 
@@ -136,12 +137,12 @@ function makePythonPackage(opts, done) {
       }
     });
     finder.on("match", function(pkgDir) {
-      var commonNsPkgs = ['google', 'google.logging'];
+      var knownNamespaces = config.pythonPkg(opts).namespaces;
       var src = path.join(opts.templateDir, '__init__.py')
       var basename = path.basename(pkgDir);
       var pkgName = pkgDir.replace(opts.top, '').replace(/^\//, '');
-      var pkgName = pkgName.replace(/\//g, '.');
-      if (opts.buildCommonProtos && _.contains(commonNsPkgs, pkgName)) {
+      pkgName = pkgName.replace(/\//g, '.');
+      if (opts.buildCommonProtos && _.contains(knownNamespaces, pkgName)) {
         src = path.join(opts.templateDir, 'namespace__init__.py')
         nsPackages.push(pkgName);
       }

--- a/templates/commonpb/python/README.rst.mustache
+++ b/templates/commonpb/python/README.rst.mustache
@@ -1,0 +1,8 @@
+=========================
+Google APIs common protos
+=========================
+
+googleapis-common-protos contains the python classes generated from the common
+protos in the googleapis_ repository.
+
+.. _`googleapis`: https://github.com/google/googleapis

--- a/templates/commonpb/python/setup.py.mustache
+++ b/templates/commonpb/python/setup.py.mustache
@@ -32,6 +32,6 @@ setuptools.setup(
   install_requires=install_requires,
   license='{{api.license}}',
   packages=find_packages(),
-  namespace_packages=['google'],
+  namespace_packages=[{{#api.nsPackages}}'{{.}}', {{/api.nsPackages}}],
   url='{{{api.homepage}}}'
 )

--- a/templates/python/setup.py.mustache
+++ b/templates/python/setup.py.mustache
@@ -35,6 +35,6 @@ setuptools.setup(
   install_requires=install_requires,
   license='{{api.license}}',
   packages=find_packages(),
-  namespace_packages=['google', 'google.{{api.simplename}}'],
+  namespace_packages=[{{#api.nsPackages}}'{{.}}', {{/api.nsPackages}}],
   url='{{{api.homepage}}}'
 )

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var _ = require('lodash');
+var config = require('../lib/config');
+var expect = require('chai').expect;
+var fs = require('fs-extra');
+var path = require('path');
+var tmp = require('tmp');
+
+function addFakeConfigFile(name, someYaml) {
+  var tmpObj = tmp.dirSync();
+  var configFile = path.join(tmpObj.name, name);
+  fs.writeFileSync(configFile, someYaml);
+  return configFile;
+}
+
+describe('config', function() {
+  var fakeYaml = "what:\n" +
+      "  - is\n" +
+      "  - this\n";
+
+  describe('method `packageInfo`', function() {
+    it('has a value by default', function() {
+      expect(config.packageInfo()).to.be.ok;
+    });
+
+    it('can load values via a config file', function() {
+      var opts = {
+        depsFile: addFakeConfigFile('deps', fakeYaml),
+        apiDefaultsFile: addFakeConfigFile('apiDefaults', fakeYaml)
+      };
+      expect(config.packageInfo(opts)).to.be.ok;
+      expect(config.packageInfo(opts).api.what).to.eql(['is', 'this']);
+      expect(config.packageInfo(opts).dependencies.what).to.eql(['is', 'this']);
+    });
+  });
+
+  describe('method `commonPbPkgs`', function() {
+    it('has a value by default', function() {
+      expect(config.commonPbPkgs()).to.be.ok;
+    });
+
+    it('can load values via a config file', function() {
+      var opts = {
+        commonPbFile: addFakeConfigFile('commonPb', fakeYaml)
+      };
+      expect(config.commonPbPkgs(opts)).to.be.ok;
+      expect(config.commonPbPkgs(opts).what).to.eql(['is', 'this']);
+    });
+  });
+
+  describe('method `pythonPkg`', function() {
+    it('has a value by default', function() {
+      expect(config.pythonPkg()).to.be.ok;
+    });
+
+    it('can load values via a config file', function() {
+      var opts = {
+        pythonPkgFile: addFakeConfigFile('pythonPkg', fakeYaml)
+      };
+      expect(config.pythonPkg(opts)).to.be.ok;
+      expect(config.pythonPkg(opts).what).to.eql(['is', 'this']);
+    });
+  });
+});

--- a/test/fixtures/setup.py
+++ b/test/fixtures/setup.py
@@ -35,6 +35,6 @@ setuptools.setup(
   install_requires=install_requires,
   license='Apache',
   packages=find_packages(),
-  namespace_packages=['google', 'google.packager'],
+  namespace_packages=['pkgTop', 'pkgTop.pkgNext', ],
   url='https://github.com/google/googleapis'
 )


### PR DESCRIPTION
Rather than assuming a static set of namespace packages, determine what they are via a simple heuristic when scanning through the python package files.

This change follows #23, and should be submitted after it