### PR TITLE
Propagate the include path.

### DIFF
--- a/bin/gen-api-package
+++ b/bin/gen-api-package
@@ -64,9 +64,10 @@ var parseArgs = function parseArgs() {
   cli.addArgument(
     [ '-i', '--include_path' ],
     {
-      help: 'Include path for additional protos.\n' +
-        'This is a PATH-like value used to locate shared proto defintions' +
-        ' outside of an apis directory, but within services_root or repository.',
+      action: 'append',
+      help: 'Include paths for additional protos.\n' +
+        'This is can specified multiple times and specifies directories' +
+        ' outside the --services_root that contain proto dependencies.',
       dest: 'includePath'
     }
   );

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -34,6 +34,10 @@ var DEFAULT_LANGUAGES = [
 // nodejs builds using ProtoBuf.js
 var NO_PROTOC_PLUGIN = ['nodejs'];
 
+// the default include path, where install the protobuf runtime installs its
+// protos.
+var DEFAULT_INCLUDE_PATH = Object.freeze(['/usr/local/include']);
+
 /**
  * ApiRepo represents a published repo containing API protos.
  */
@@ -43,6 +47,7 @@ function ApiRepo(opts) {
   this.opts = opts;
   this.packageInfo = config.packageInfo(opts);
   this.commonPb = config.commonPb(opts);
+  this.includePath = opts.includePath || DEFAULT_INCLUDE_PATH;
   this.languages = opts.languages || DEFAULT_LANGUAGES;
   this.outDir = opts.outDir || tmp.dirSync().name;
   this.repoDir = opts.repoDir;
@@ -319,10 +324,11 @@ ApiRepo.prototype._buildProtos =
           findOutputs(err);
           return;
         }
+        var includePath = _.union(that.includePath, [that.repoDir]);
         var opts = {
           root: that.repoDir,
           source: 'proto',
-          path: ['/usr/local/include', that.repoDir]
+          path: includePath
         };
 
         var builder = loadProtos(allProtos, opts);
@@ -601,6 +607,9 @@ ApiRepo.prototype._makeProtocFunc = function _makeProtocFunc(opts, language) {
         pluginBin = that.depBins[that.overridePlugins[language]];
       }
       args.push('--' + language + '_out=' + outDir, '-I.');
+      _.each(that.includePath, function(aPath) {
+        args.push('-I' + aPath);
+      });
       if (!opts.buildCommonProtos) {
         args.push('--grpc_out=' + outDir,
                   '--plugin=protoc-gen-grpc=' + pluginBin);

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -315,6 +315,7 @@ describe('ApiRepo', function() {
         // The test uses the fake protoc, so it just echoes its args
         var want = '--python_out=' + path.join(repo.outDir, 'python');
         want += ' -I.';
+        want += ' -I/usr/local/include';
         want += ' --grpc_out=' + path.join(repo.outDir, 'python');
         want += ' --plugin=protoc-gen-grpc=/testing/bin/my_python_plugin';
         want += ' ' + fakeProto + '\n';
@@ -327,6 +328,28 @@ describe('ApiRepo', function() {
       }, 'python');
       protoc(fakeProto, shouldPass);
     });
+    it('should obtain a func that runs protoc with the right includePath',
+       function(done) {
+         var shouldPass = function(err, got) {
+           expect(err).to.be.null();
+           // The test uses the fake protoc, so it just echoes its args
+           var want = '--python_out=' + path.join(repo.outDir, 'python');
+           want += ' -I.';
+           want += ' -I/an/include/path';
+           want += ' -I/another/include/path';
+           want += ' --grpc_out=' + path.join(repo.outDir, 'python');
+           want += ' --plugin=protoc-gen-grpc=/testing/bin/my_python_plugin';
+           want += ' ' + fakeProto + '\n';
+        expect(got).to.contain(want);
+           done();
+         };
+         repo.depBins = {'grpc_python_plugin': '/testing/bin/my_python_plugin'};
+         repo.includePath = ['/an/include/path', '/another/include/path'];
+         var protoc = repo._makeProtocFunc({
+           env: {'PATH': fakes.path}
+         }, 'python');
+         protoc(fakeProto, shouldPass);
+       });
     it('should obtain a func that runs protoc for GoLang', function(done) {
       var shouldPass = function(err, got) {
         expect(err).to.be.null();


### PR DESCRIPTION
- gen-api-package has a -i, --include_path flag, it's value is not being
  propagated to protoc, or the other commands used to create packages.

This change corrects that.

Fixes #36 