### PR TITLE
Display errors that occur during buildPackage

### DIFF
--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -170,16 +170,7 @@ ApiRepo.prototype.buildPackages =
   function buildPackages(name, version, opt_done) {
     var tasks = [];
     var that = this;
-
-    /** done emits errors that occur during processing */
-    var done = function done(err) {
-      if (err) {
-        that.emit('error', err);
-      }
-      if (opt_done) {
-        opt_done(err);
-      }
-    };
+    var done = this._wrap_done(opt_done);
 
     var templateInfo = rootTemplateDir(defaultTemplateInfo, this.templateRoot);
     this.languages.forEach(function(l) {
@@ -228,6 +219,20 @@ var commonPbTemplateInfo = {
   }
 };
 
+/**
+ * _wrap_done wraps the optional 'done' callback used in the buildXXX methods,
+ * ensuring that errors trigger the error event.
+ */
+ApiRepo.prototype._wrap_done = function _wrap_done(opt_done) {
+  return function done(err) {
+    if (err) {
+      this.emit('error', err);
+    }
+    if (opt_done) {
+      opt_done(err);
+    }
+  }.bind(this);
+};
 
 /**
  * buildCommonProtoPkgs builds the core proto packages in the configured
@@ -250,16 +255,7 @@ ApiRepo.prototype.buildCommonProtoPkgs =
   function buildCommonProtoPkgs(opt_done) {
     var tasks = [];
     var that = this;
-
-    /** done emits errors that occur during processing */
-    var done = function done(err) {
-      if (err) {
-        that.emit('error', err);
-      }
-      if (opt_done) {
-        opt_done(err);
-      }
-    };
+    var done = this._wrap_done(opt_done);
 
     var templateRoot = path.join(__dirname, '..', 'templates', 'commonpb');
     var templateInfo = rootTemplateDir(commonPbTemplateInfo, templateRoot);

--- a/lib/api_repo.js
+++ b/lib/api_repo.js
@@ -170,7 +170,17 @@ ApiRepo.prototype.buildPackages =
   function buildPackages(name, version, opt_done) {
     var tasks = [];
     var that = this;
-    var done = opt_done || _.noop;
+
+    /** done emits errors that occur during processing */
+    var done = function done(err) {
+      if (err) {
+        that.emit('error', err);
+      }
+      if (opt_done) {
+        opt_done(err);
+      }
+    };
+
     var templateInfo = rootTemplateDir(defaultTemplateInfo, this.templateRoot);
     this.languages.forEach(function(l) {
       var innerTasks = [that._buildProtos.bind(that, name, version, l)];
@@ -188,7 +198,7 @@ ApiRepo.prototype.buildPackages =
         };
         innerTasks.push(buildAPackage);
       }
-      tasks.push(async.waterfall.bind(async, innerTasks));
+      tasks.push(async.waterfall.bind(null, innerTasks));
     });
     async.parallel(tasks, done);
   };
@@ -240,7 +250,17 @@ ApiRepo.prototype.buildCommonProtoPkgs =
   function buildCommonProtoPkgs(opt_done) {
     var tasks = [];
     var that = this;
-    var done = opt_done || _.noop;
+
+    /** done emits errors that occur during processing */
+    var done = function done(err) {
+      if (err) {
+        that.emit('error', err);
+      }
+      if (opt_done) {
+        opt_done(err);
+      }
+    };
+
     var templateRoot = path.join(__dirname, '..', 'templates', 'commonpb');
     var templateInfo = rootTemplateDir(commonPbTemplateInfo, templateRoot);
     this.languages.forEach(function(l) {

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -222,7 +222,6 @@ function makeJavaPackage(opts, done) {
   opts.copyables.forEach(function(f) {
     var src = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, f);
-    console.log('Copying %s to %s', src, dst);
     tasks.push(fs.copy.bind(fs, src, dst));
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-packman",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "bin": {
     "gen-api-package": "bin/gen-api-package"
   },

--- a/test/api_repo.js
+++ b/test/api_repo.js
@@ -84,6 +84,9 @@ describe('ApiRepo', function() {
             expect(err).to.not.be.null();
             done();
           };
+          repo.on('error', function(err) {
+            expect(err).to.not.be.null();
+          });
           repo.on('ready', function() {
             repo.buildPackages('notpubsub', 'v1beta2', shouldFail);
           });
@@ -162,7 +165,7 @@ describe('ApiRepo', function() {
         });
         it('should fail on unrecognized apis', function(done) {
           repo.on('error', function(err) {
-            throw new Error('should not be reached');
+            expect(err).to.not.be.null();
           });
           var shouldFail = function shouldFail(err) {
             expect(err).to.not.be.null();
@@ -175,7 +178,7 @@ describe('ApiRepo', function() {
         });
         it('should fail on unrecognized versions', function(done) {
           repo.on('error', function(err) {
-            throw new Error('should not be reached');
+            expect(err).to.not.be.null();
           });
           var shouldFail = function shouldFail(err) {
             expect(err).to.not.be.null();


### PR DESCRIPTION
- these were being hidden, as the error ApiRepo 'error' event was not
  being triggered by buildPackage errors. This change corrects that.

Also:
 - removes some unnecessary trace in the java package builder

Fixes #37
