### PR TITLE
Replace LICENSE symlinks with an actual file

### DIFF
--- a/lib/packager.js
+++ b/lib/packager.js
@@ -20,7 +20,7 @@ var settings = {
   'go': {
     'copyables': [
       'PUBLISHING.md',
-      'LICENSE'
+      '../LICENSE'
     ]
   },
   'java': {
@@ -30,7 +30,7 @@ var settings = {
       'gradlew',
       'gradlew.bat',
       'PUBLISHING.md',
-      'LICENSE'
+      '../LICENSE'
     ],
     'templates': [
       'build.gradle.mustache'
@@ -39,7 +39,7 @@ var settings = {
   'nodejs': {
     'copyables': [
       'PUBLISHING.md',
-      'LICENSE',
+      '../LICENSE',
       'index.js'
     ],
     'templates': [
@@ -50,7 +50,7 @@ var settings = {
   'objective_c': {
     'copyables': [
       'PUBLISHING.md',
-      'LICENSE'
+      '../LICENSE'
     ],
     'templates': [
       'podspec.mustache'
@@ -59,7 +59,7 @@ var settings = {
   'python': {
     'copyables': [
       'PUBLISHING.rst',
-      'LICENSE'
+      '../LICENSE'
     ],
     'templates': [
       'README.rst.mustache',
@@ -70,7 +70,7 @@ var settings = {
     'copyables': [
       'Gemfile',
       'PUBLISHING.md',
-      'LICENSE',
+      '../LICENSE',
       'Rakefile'
     ],
     'templates': [
@@ -93,6 +93,9 @@ function makeGolangPackage(opts, done) {
   opts.copyables.forEach(function(f) {
     var src = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, f);
+    if (f === '../LICENSE') {
+      dst = path.join(opts.top, 'LICENSE');
+    }
     tasks.push(fs.copy.bind(fs, src, dst));
   });
 
@@ -124,6 +127,9 @@ function makePythonPackage(opts, done) {
   opts.copyables.forEach(function(f) {
     var src = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, f);
+    if (f === '../LICENSE') {
+      dst = path.join(opts.top, 'LICENSE');
+    }
     tasks.push(fs.copy.bind(fs, src, dst));
   });
 
@@ -222,6 +228,9 @@ function makeJavaPackage(opts, done) {
   opts.copyables.forEach(function(f) {
     var src = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, f);
+    if (f === '../LICENSE') {
+      dst = path.join(opts.top, 'LICENSE');
+    }
     tasks.push(fs.copy.bind(fs, src, dst));
   });
 
@@ -263,6 +272,9 @@ function makeNodejsPackage(opts, done) {
   opts.copyables.forEach(function(f) {
     var src = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, f);
+    if (f === '../LICENSE') {
+      dst = path.join(opts.top, 'LICENSE');
+    }
     tasks.push(fs.copy.bind(fs, src, dst));
   });
 
@@ -307,6 +319,9 @@ function makeObjcPackage(opts, done) {
   opts.copyables.forEach(function(f) {
     var src = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, f);
+    if (f === '../LICENSE') {
+      dst = path.join(opts.top, 'LICENSE');
+    }
     tasks.push(fs.copy.bind(fs, src, dst));
   });
 
@@ -357,6 +372,9 @@ function makeRubyPackage(opts, done) {
   opts.copyables.forEach(function(f) {
     var src = path.join(opts.templateDir, f)
       , dst = path.join(opts.top, f);
+    if (f === '../LICENSE') {
+      dst = path.join(opts.top, 'LICENSE');
+    }
     tasks.push(fs.copy.bind(fs, src, dst));
   });
 

--- a/templates/LICENSE
+++ b/templates/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2015, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/templates/commonpb/LICENSE
+++ b/templates/commonpb/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2015, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/templates/commonpb/go/LICENSE
+++ b/templates/commonpb/go/LICENSE
@@ -1,1 +1,0 @@
-LICENSE

--- a/templates/commonpb/python/LICENSE
+++ b/templates/commonpb/python/LICENSE
@@ -1,1 +1,0 @@
-LICENSE

--- a/templates/commonpb/ruby/LICENSE
+++ b/templates/commonpb/ruby/LICENSE
@@ -1,1 +1,0 @@
-LICENSE

--- a/templates/go/LICENSE
+++ b/templates/go/LICENSE
@@ -1,1 +1,0 @@
-LICENSE

--- a/templates/java/LICENSE
+++ b/templates/java/LICENSE
@@ -1,1 +1,0 @@
-LICENSE

--- a/templates/nodejs/LICENSE
+++ b/templates/nodejs/LICENSE
@@ -1,1 +1,0 @@
-LICENSE

--- a/templates/objc/LICENSE
+++ b/templates/objc/LICENSE
@@ -1,1 +1,0 @@
-LICENSE

--- a/templates/python/LICENSE
+++ b/templates/python/LICENSE
@@ -1,1 +1,0 @@
-LICENSE

--- a/templates/ruby/LICENSE
+++ b/templates/ruby/LICENSE
@@ -1,1 +1,0 @@
-LICENSE


### PR DESCRIPTION
- This is because the LICENSE symlinks don't get packaged correctly when
  the npm package is published

Fixes #37